### PR TITLE
fix: add CommandAuthorized to ctxPayload for reset triggers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1470,6 +1470,7 @@ async function processInboundMessage({ api, fromUser, content, msgType, mediaId,
       Timestamp: Date.now(),
       OriginatingChannel: "wecom",
       OriginatingTo: `wecom:${fromUser}`,
+      CommandAuthorized: true,
     };
 
     // 注册会话到 Sessions UI


### PR DESCRIPTION
## Problem
`/new` and `/reset` commands are silently ignored in the WeChat channel. Users cannot start a new session.
## Root Cause
The `ctxPayload` in [processInboundMessage](cci:1://file:///Users/jcan/program/fast-dev/openclaw-wechat/src/index.js:1203:0-1619:1) is missing `CommandAuthorized: true`. Without this field, OpenClaw core treats all WeChat senders as unauthorized, causing [initSessionState](cci:1://file:///Users/jcan/program/fast-dev/clawdbot/src/auto-reply/reply/session.ts:96:0-455:1) to skip reset trigger detection.
## Fix
Add `CommandAuthorized: true` to the context payload. Enterprise WeChat self-built app messages come from verified internal members, so they should always be treated as authorized.
## Testing
Verified that after the fix:
- `/new` correctly generates a new sessionId and creates a new session transcript file
- `/models`, `/status`, `/help`, `/clear` continue to work as expected