### PR TITLE
fix: 为 webhook 路由注册补充 auth 参数

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -938,6 +938,7 @@ export default function register(api) {
 
   api.registerHttpRoute({
     path: normalizedPath,
+    auth: "plugin",
     handler: async (req, res) => {
       const config = getWecomConfig(api);
       const token = config?.callbackToken;


### PR DESCRIPTION
适配 OpenClaw v2026.3.2 引入的插件 HTTP 路由注册 breaking change。
 `registerHttpRoute` 现要求显式声明 `auth`。

> BREAKING: Plugin SDK removed `api.registerHttpHandler(...)`. Plugins must register explicit HTTP routes via `api.registerHttpRoute({ path, auth, match, handler })`, and dynamic webhook lifecycles should use `registerPluginHttpRoute(...)`.

详见 OpenClaw v2026.3.2 CHANGELOG / release notes。

修复前相关错误日志:
```text
[plugins] http route registration missing or invalid auth: /wecom/callback (plugin=wecom, source=/alex/.openclaw/extensions/wecom/index.js)
```